### PR TITLE
ASTT-79 Updated Az and El degree limits as per URS

### DIFF
--- a/src/astt_gui/templates/index.html
+++ b/src/astt_gui/templates/index.html
@@ -441,14 +441,14 @@
                           <div class="row mb-3">
                             <label for="inputText" class="col-sm-2 col-form-label">Azimith</label>
                             <div class="col-sm-10">
-                              <input type="number" step="0.01" id="azimuth" class="form-control" name ="azimuth" required="required">
+                              <input type="number" placeholder="Az values limited to (-127) to (127)" step="0.01" id="azimuth" class="form-control" name ="azimuth" required="required" min="-127" max="127">
                               <span style="font-style: italic; color: red;" id="azErrorMsg"></span>
                             </div>
                           </div>
                           <div class="row mb-3">
                             <label for="inputEmail" class="col-sm-2 col-form-label">Elevation</label>
                             <div class="col-sm-10">
-                              <input type="number" step="0.01" id="elevation" class="form-control" name="elevation" required="required">
+                              <input type="number" placeholder="El values limited to (-15) to (92)" step="0.01" id="elevation" class="form-control" name="elevation" required="required" min="-15" max="92">
                               <span style="font-style: italic; color: red;" id="elErrorMsg"></span>
                             </div>
                             <div class="modal-footer">

--- a/src/component_managers/astt_comp_manager.py
+++ b/src/component_managers/astt_comp_manager.py
@@ -265,7 +265,7 @@ class ASTTComponentManager:
 
     def is_el_allowed(self, el):
         """Allows elevation of [-15,92]"""
-        return True if (el >= -15.0 and el <= 91.0) else False
+        return True if (el >= -15.0 and el <= 92.0) else False
 
     def point_to_coordinates(self, timestamp, az, el):
         """commands the simulator to point az/el ."""

--- a/tests/unit/test_az_el_limits.py
+++ b/tests/unit/test_az_el_limits.py
@@ -28,6 +28,22 @@ class TestAzElLimits(unittest.TestCase):
         """Test with input out of range of [-15,92]"""
         self.assertFalse(self.cm.is_el_allowed(95.0))
 
+    def test_el_min_bound(self):
+        "Test with minimum bound of -15"
+        self.assertTrue(self.cm.is_el_allowed(-15.0))
+
+    def test_el_max_bound(self):
+        "Test with maximum bound of 92"
+        self.assertTrue(self.cm.is_el_allowed(92))
+
+    def test_az_min_bound(self):
+        "Test with minimum bound of -127"
+        self.assertTrue(self.cm.is_az_allowed(-127.0))
+
+    def test_az_max_bound(self):
+        "Test with maximum bound of 127"
+        self.assertTrue(self.cm.is_az_allowed(127.0))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_pointing.py
+++ b/tests/unit/test_pointing.py
@@ -10,7 +10,6 @@ from src.component_managers.astt_comp_manager import (
 
 
 class TestAntennaPointing(unittest.TestCase):
-
     @patch("src.component_managers.astt_comp_manager.canopen.Network")
     @patch(
         "src.component_managers.astt_comp_manager.canopen.RemoteNode"


### PR DESCRIPTION
Updated Az and El limits as per [URS](https://docs.google.com/document/d/1WJAMXM0CW2HakxTgxgIn8U9u-iWUjyHqZc81Qq7KjT4/edit) on the GUI 

Changes: 
* Text boxes on the point modal restrict users to go beyond or below the limits, images are shown below.
* Placeholder text shows a user the limits for Az and El
* Pop-up warning prevents a user from pressing button when Az and El values are out of bounds.

![Screenshot from 2024-02-22 09-22-21](https://github.com/AbednigoLethole/asst-cam-software/assets/123445025/4588c439-5270-4b5a-9754-daa7e0ef4adc)
![Screenshot from 2024-02-22 09-22-12](https://github.com/AbednigoLethole/asst-cam-software/assets/123445025/d0133d3f-cc69-4773-acee-e3e56c734bf2)
![Screenshot from 2024-02-22 09-21-56](https://github.com/AbednigoLethole/asst-cam-software/assets/123445025/365e72bb-d3dc-4b96-b775-ffc6a99bf65f)
